### PR TITLE
chore: Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug Report
+about: Report errors, broken links, or display issues in the documentation
+title: "[BUG] "
+labels: bug
+assignees: ''
+
+---
+
+**Page(s) Affected**
+Link to the page(s) or file(s) where the issue occurs.
+
+**Describe the bug**
+A clear and concise description of what the bug is (e.g., broken link, typo, rendering error).
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment**
+Please complete the following information if relevant (e.g., for layout/rendering issues):
+
+- Device: [e.g. Desktop, Mobile]
+- OS: [e.g. Windows, macOS, iOS]
+- Browser: [e.g. Chrome, Safari]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/content_request.md
+++ b/.github/ISSUE_TEMPLATE/content_request.md
@@ -1,0 +1,20 @@
+---
+name: Content Request
+about: Suggest new content or updates to existing content
+title: "[CONTENT] "
+labels: content
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when...
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -1,0 +1,34 @@
+---
+name: General Task
+about: Create a task for features, chores, fixes, or refactoring
+title: "[TYPE]: "
+labels: ''
+assignees: ''
+
+---
+
+## Summary
+
+Briefly summarize the task.
+
+## Description
+
+Provide a detailed description of the task. Explain the problem it solves and why it's needed.
+
+## Requirements
+
+List the specific requirements for this task.
+
+- [ ] Requirement 1
+- [ ] Requirement 2
+
+## Acceptance Criteria
+
+Define the criteria that must be met for this task to be considered complete.
+
+- [ ] Criteria 1
+- [ ] Criteria 2
+
+## Additional Notes
+
+Add any other context, screenshots, or notes here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## Description
+
+Please include a summary of the content changes and which issue is fixed. If this is a new guide or resource, briefly explain its purpose.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] New Content (new guide, learning path, or resource page)
+- [ ] Content Update (improvements or additions to existing content)
+- [ ] Bug fix (typos, broken links, formatting issues)
+- [ ] Configuration (changes to docs.json or project structure)
+
+## Content Checklist
+
+- [ ] My content is written in Markdown/MDX.
+- [ ] I have included the required frontmatter (title, description, etc.) at the top of the file.
+- [ ] I have checked for spelling and grammar errors.
+- [ ] I have verified that all links (internal and external) are working.
+- [ ] I have optimized any images used and stored them in the `images/` directory (if applicable).
+- [ ] I have added the new page to `docs.json` navigation (if applicable).
+- [ ] I have previewed my changes locally to ensure proper formatting.
+
+## Additional Notes
+
+Add any other context, screenshots, or notes about the PR here.


### PR DESCRIPTION
## Description

This pull request introduces standardized GitHub Issue and Pull Request templates to improve project workflow, ensure consistent reporting, and streamline collaboration.

The update adds:
- A default issue template (`issue.md`) under `.github/ISSUE_TEMPLATE/`
- A pull request template (`pull_request_template.md`) under `.github/`

Fixes #16

## Type of change
- [x] Configuration (changes to docs.json or project structure)

## Content Checklist

- [x] My content is written in Markdown/MDX.
- [x] I have included the required frontmatter (title, description, etc.) at the top of the file. *(Not applicable—templates do not require frontmatter)*
- [x] I have checked for spelling and grammar errors.
- [x] I have verified that all links (internal and external) are working.
- [x] I have previewed my changes locally to ensure proper formatting.

## Additional Notes

This update establishes the foundation for consistent contribution standards across the project and improves clarity for both maintainers and contributors.
